### PR TITLE
floating numbers (obstruction pixels) between (0, 1) should be treated as 1

### DIFF
--- a/satellite.py
+++ b/satellite.py
@@ -29,7 +29,8 @@ def capture_snr_data(duration_seconds, interval_seconds, context):
     while time.time() < end_time:
         try:
             snr_data = starlink_grpc.obstruction_map(context)
-            snr_data_array = np.array(snr_data, dtype=int)
+            snr_data_array = np.array(snr_data, dtype=float)
+            snr_data_array = (snr_data_array > 0).astype(int)
             snr_data_array[snr_data_array == -1] = 0
             snapshots.append(snr_data_array)
             time.sleep(interval_seconds)


### PR DESCRIPTION
raw data from the grpc interface about obstruction map could be floating numbers between 0 and 1, meaning the area is (partially) obstructed, see https://github.com/sparky8512/starlink-grpc-tools/blob/a3860e0a73d0b2280eed92eb8a2a97de0ea5fe43/dish_obstruction_map.py#L59-L87

obstructed pixel should still be treated as 1 in order to determine connected satellite locations. 

`a = np.array([0.1, 0, 0, 0], dtype=int)` gets `a = [0 0 0 0]`, but actually we need `[1 0 0 0]`